### PR TITLE
Split subproblems

### DIFF
--- a/danny/src/cartesian.rs
+++ b/danny/src/cartesian.rs
@@ -1,4 +1,4 @@
-use danny_base::types::ElementId;
+use crate::operators::Route;
 
 /// Utilities to compute the (self) cartesian product of a stream.
 ///
@@ -28,8 +28,8 @@ impl SelfCartesian {
         }
     }
 
-    pub fn keys_for(&self, k: ElementId) -> impl Iterator<Item = (CartesianKey, Marker)> {
-        let diag_id = (k.0 % self.groups as u32) as u8;
+    pub fn keys_for<R: Route>(&self, k: R) -> impl Iterator<Item = (CartesianKey, Marker)> {
+        let diag_id = (k.route() % self.groups as u64) as u8;
         let diag = Some((CartesianKey(diag_id, diag_id), Marker::Both));
         let rows = (0..diag_id).map(move |i| (CartesianKey(i, diag_id), Marker::Left));
         let cols =

--- a/danny/src/cartesian.rs
+++ b/danny/src/cartesian.rs
@@ -93,6 +93,29 @@ fn test_for_peers() {
 }
 
 #[test]
+fn test_with_groups() {
+    let cartesian = SelfCartesian::with_groups(2);
+    assert_eq!(cartesian.num_cells, 3);
+    assert_eq!(cartesian.groups, 2);
+}
+
+#[test]
+fn test_keys_for() {
+    use Marker::*;
+    let cartesian = SelfCartesian::with_groups(2);
+    let k0: Vec<(CartesianKey, Marker)> = cartesian.keys_for(0).collect();
+    assert_eq!(
+        k0,
+        vec![(CartesianKey(0, 0), Both), (CartesianKey(0, 1), Right)]
+    );
+    let k1: Vec<(CartesianKey, Marker)> = cartesian.keys_for(1).collect();
+    assert_eq!(
+        k1,
+        vec![(CartesianKey(1, 1), Both), (CartesianKey(0, 1), Left)]
+    );
+}
+
+#[test]
 fn test_diagonal_order() {
     let mut keys = Vec::new();
     let n = 5;

--- a/danny/src/config.rs
+++ b/danny/src/config.rs
@@ -12,6 +12,8 @@ use std::process::Command;
 use timely::communication::{Allocator, Configuration as TimelyConfig, WorkerGuards};
 use timely::worker::Worker;
 
+use crate::join::Balance;
+
 pub fn get_hostname() -> String {
     let output = Command::new("hostname")
         .output()
@@ -77,6 +79,10 @@ pub struct Config {
     /// number of repetitions to squash together
     #[argh(option, default = "1")]
     pub repetition_batch: usize,
+
+    /// what to load balance
+    #[argh(option, default = "Balance::Load")]
+    pub balance: Balance,
 
     /// wether to run again the given configuration,
     /// even if already present in the database

--- a/danny/src/experiment.rs
+++ b/danny/src/experiment.rs
@@ -185,10 +185,12 @@ impl Experiment {
                     total_time_ms,
                     output_size,
                     recall,
-                    speedup
+                    speedup,
+
+                    balance
                 )
                  VALUES (
-                     ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23
+                     ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24
                  )",
                 params![
                     sha,
@@ -214,7 +216,8 @@ impl Experiment {
                     self.total_time_ms,
                     self.output_size,
                     recall,
-                    speedup
+                    speedup,
+                    format!("{:?}", self.config.balance)
                 ],
             )
             .expect("error inserting into main table");
@@ -266,6 +269,11 @@ fn db_migrate(conn: &Connection) {
         info!("Applying migration v2");
         conn.execute_batch(include_str!("migrations/v2.sql"))
             .expect("error applying version 2");
+    }
+    if version < 3 {
+        info!("Applying migration v3");
+        conn.execute_batch(include_str!("migrations/v3.sql"))
+            .expect("error applying version 3");
     }
 
     info!("Database migration completed!");

--- a/danny/src/join.rs
+++ b/danny/src/join.rs
@@ -152,7 +152,6 @@ where
                         processor_allocations[i].push((key, subproblem_key, marker));
                         cur += subproblem_size;
                     }
-                    info!("allocations: {:?}", processor_allocations);
 
                     let mut subproblem_allocations = HashMap::new();
                     for (p, allocs) in processor_allocations.into_iter().enumerate() {

--- a/danny/src/join.rs
+++ b/danny/src/join.rs
@@ -104,7 +104,7 @@ where
                     sizes.sort_unstable_by_key(|x| x.1);
 
                     // Define a threshold for heavy hitters
-                    let threshold = sizes[0].1 * 2;
+                    let threshold = sizes[sizes.len() / 2].1;
                     if worker_index == 0 {
                         info!(
                             "there are {} subproblems, threshold {}",

--- a/danny/src/join.rs
+++ b/danny/src/join.rs
@@ -104,7 +104,7 @@ where
                     sizes.sort_unstable_by_key(|x| x.1);
 
                     // Define a threshold for heavy hitters
-                    let threshold = sizes[sizes.len() / 2].1;
+                    let threshold = sizes[0].1 * 2;
                     if worker_index == 0 {
                         info!(
                             "there are {} subproblems, threshold {}",

--- a/danny/src/join.rs
+++ b/danny/src/join.rs
@@ -11,9 +11,22 @@ use timely::dataflow::operators::*;
 use timely::dataflow::*;
 use timely::ExchangeData;
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Balance {
     Load,
     SubproblemSize,
+}
+
+impl std::str::FromStr for Balance {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Load" | "load" => Ok(Self::Load),
+            "SubproblemSize" | "subproblemsize" | "size" => Ok(Self::SubproblemSize),
+            _ => Err(format!("unknown balancing {}", s)),
+        }
+    }
 }
 
 impl Balance {

--- a/danny/src/join.rs
+++ b/danny/src/join.rs
@@ -108,7 +108,7 @@ where
                     let total_pairs = sizes.iter().map(|p| subproblem_pairs(p.1)).sum::<u32>();
 
                     // Split subproblems that are too big
-                    let threshold = total_pairs / peers as u32;
+                    let threshold = (total_pairs as f64 / peers as f64).ceil() as u32;
                     let mut subproblems: Vec<(K, CartesianKey, Marker, u32)> = sizes
                         .into_iter()
                         .flat_map(|(key, size)| {

--- a/danny/src/join.rs
+++ b/danny/src/join.rs
@@ -125,16 +125,26 @@ where
                         })
                         .collect();
                     subproblems.sort_unstable_by_key(|x| std::cmp::Reverse(x.3));
+                    let n_subproblems = subproblems.len();
 
                     // Allocate subproblems to processors
                     let mut processor_allocations = vec![Vec::new(); peers];
                     info!("threshold {}", threshold);
                     let mut i = 0;
                     let mut cur = 0;
-                    for (key, subproblem_key, marker, subproblem_size) in subproblems {
+                    for (sub_idx, (key, subproblem_key, marker, subproblem_size)) in
+                        subproblems.into_iter().enumerate()
+                    {
                         if cur > threshold {
                             cur = 0;
                             i += 1;
+                        }
+                        if i >= processor_allocations.len() {
+                            panic!(
+                                "number or processors ({}) exceeded: still {} to go",
+                                peers,
+                                n_subproblems - sub_idx
+                            );
                         }
                         processor_allocations[i].push((key, subproblem_key, marker));
                         cur += subproblem_size;

--- a/danny/src/logging.rs
+++ b/danny/src/logging.rs
@@ -332,7 +332,7 @@ pub enum LogEvent {
     SketchDiscarded(usize),
     DistinctPairs(usize),
     DuplicatesDiscarded(usize),
-    GeneratedPairs(usize),
+    OutputPairs(usize),
     /// The number of received hashes during bucketing. This is a proxy for the load measure
     ReceivedHashes(usize),
     // The hashes generated in each iteration
@@ -347,7 +347,7 @@ impl LogEvent {
             SketchDiscarded(_) => String::from("SketchDiscarded"),
             DistinctPairs(_) => String::from("DistinctPairs"),
             DuplicatesDiscarded(_) => String::from("DuplicatesDiscarded"),
-            GeneratedPairs(_) => String::from("GeneratedPairs"),
+            OutputPairs(_) => String::from("OutputPairs"),
             ReceivedHashes(_) => String::from("ReceivedHashes"),
             GeneratedHashes(_) => String::from("GeneratedHashes"),
         }
@@ -360,7 +360,7 @@ impl LogEvent {
             SketchDiscarded(step) => *step as u32,
             DistinctPairs(step) => *step as u32,
             DuplicatesDiscarded(step) => *step as u32,
-            GeneratedPairs(step) => *step as u32,
+            OutputPairs(step) => *step as u32,
             ReceivedHashes(step) => *step as u32,
             GeneratedHashes(step) => *step as u32,
         }

--- a/danny/src/lsh/algorithms/hu_et_al.rs
+++ b/danny/src/lsh/algorithms/hu_et_al.rs
@@ -234,7 +234,7 @@ where
                         logger,
                         (LogEvent::SketchDiscarded(repetition), sketch_discarded)
                     );
-                    log_event!(logger, (LogEvent::GeneratedPairs(repetition), cnt));
+                    log_event!(logger, (LogEvent::OutputPairs(repetition), cnt));
                     log_event!(
                         logger,
                         (LogEvent::DuplicatesDiscarded(repetition), duplicate_cnt)

--- a/danny/src/lsh/algorithms/hu_et_al.rs
+++ b/danny/src/lsh/algorithms/hu_et_al.rs
@@ -26,7 +26,7 @@ use timely::progress::Timestamp;
 use timely::worker::Worker;
 use timely::ExchangeData;
 
-pub const HU_ET_AL_VERSION: u8 = 1;
+pub const HU_ET_AL_VERSION: u8 = 2;
 
 pub fn source_hashed_one_round<G, T, D, S, F>(
     scope: &G,

--- a/danny/src/lsh/algorithms/hu_et_al.rs
+++ b/danny/src/lsh/algorithms/hu_et_al.rs
@@ -1,7 +1,7 @@
 use crate::config::*;
 use crate::experiment::Experiment;
 use crate::io::*;
-use crate::join::Join;
+use crate::join::*;
 
 use crate::logging::*;
 use crate::lsh::repetition_stopwatch::*;
@@ -26,7 +26,7 @@ use timely::progress::Timestamp;
 use timely::worker::Worker;
 use timely::ExchangeData;
 
-pub const HU_ET_AL_VERSION: u8 = 2;
+pub const HU_ET_AL_VERSION: u8 = 3;
 
 pub fn source_hashed_one_round<G, T, D, S, F>(
     scope: &G,
@@ -168,56 +168,60 @@ where
         );
 
         hashes
-            .self_join_map(move |((repetition, _hash), subproblem_key), values| {
-                let mut cnt = 0usize;
-                let mut total = 0usize;
-                let mut sketch_discarded = 0;
-                let mut duplicate_cnt = 0usize;
-                let start = Instant::now();
+            .self_join_map(
+                Balance::Load,
+                move |((repetition, _hash), subproblem_key), values| {
+                    let mut cnt = 0usize;
+                    let mut total = 0usize;
+                    let mut sketch_discarded = 0;
+                    let mut duplicate_cnt = 0usize;
+                    let start = Instant::now();
 
-                if subproblem_key.on_diagonal() {
-                    for (i, (_, (_l, l_pool, l_sketch, l))) in values.iter().enumerate() {
-                        for (_, (_r, r_pool, r_sketch, r)) in values[i..].iter() {
-                            total += 1;
-                            if sketch_predicate.eval(l_sketch, r_sketch) {
-                                if no_verify || sim_pred(l, r) {
-                                    if no_dedup || !hasher.already_seen(l_pool, r_pool, repetition)
-                                    {
-                                        cnt += 1;
-                                    } else {
-                                        duplicate_cnt += 1;
-                                    }
-                                }
-                            } else {
-                                sketch_discarded += 1;
-                            }
-                        }
-                    }
-                } else {
-                    for (l_marker, (_l, l_pool, l_sketch, l)) in values.iter() {
-                        if l_marker.keep_left() {
-                            for (r_marker, (_r, r_pool, r_sketch, r)) in values.iter() {
-                                if r_marker.keep_right() {
-                                    total += 1;
-                                    if sketch_predicate.eval(l_sketch, r_sketch) {
-                                        if no_verify || sim_pred(l, r) {
-                                            if no_dedup
-                                                || !hasher.already_seen(l_pool, r_pool, repetition)
-                                            {
-                                                cnt += 1;
-                                            } else {
-                                                duplicate_cnt += 1;
-                                            }
+                    if subproblem_key.on_diagonal() {
+                        for (i, (_, (_l, l_pool, l_sketch, l))) in values.iter().enumerate() {
+                            for (_, (_r, r_pool, r_sketch, r)) in values[i..].iter() {
+                                total += 1;
+                                if sketch_predicate.eval(l_sketch, r_sketch) {
+                                    if no_verify || sim_pred(l, r) {
+                                        if no_dedup
+                                            || !hasher.already_seen(l_pool, r_pool, repetition)
+                                        {
+                                            cnt += 1;
+                                        } else {
+                                            duplicate_cnt += 1;
                                         }
-                                    } else {
-                                        sketch_discarded += 1;
+                                    }
+                                } else {
+                                    sketch_discarded += 1;
+                                }
+                            }
+                        }
+                    } else {
+                        for (l_marker, (_l, l_pool, l_sketch, l)) in values.iter() {
+                            if l_marker.keep_left() {
+                                for (r_marker, (_r, r_pool, r_sketch, r)) in values.iter() {
+                                    if r_marker.keep_right() {
+                                        total += 1;
+                                        if sketch_predicate.eval(l_sketch, r_sketch) {
+                                            if no_verify || sim_pred(l, r) {
+                                                if no_dedup
+                                                    || !hasher
+                                                        .already_seen(l_pool, r_pool, repetition)
+                                                {
+                                                    cnt += 1;
+                                                } else {
+                                                    duplicate_cnt += 1;
+                                                }
+                                            }
+                                        } else {
+                                            sketch_discarded += 1;
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }
-                debug!(
+                    debug!(
                     "Candidates {}: Emitted {} / Sketch discarded {} / Duplicates {} in {:?} ({})",
                     total,
                     cnt,
@@ -226,17 +230,18 @@ where
                     Instant::now() - start,
                     proc_mem!(),
                 );
-                log_event!(
-                    logger,
-                    (LogEvent::SketchDiscarded(repetition), sketch_discarded)
-                );
-                log_event!(logger, (LogEvent::GeneratedPairs(repetition), cnt));
-                log_event!(
-                    logger,
-                    (LogEvent::DuplicatesDiscarded(repetition), duplicate_cnt)
-                );
-                Some(cnt)
-            })
+                    log_event!(
+                        logger,
+                        (LogEvent::SketchDiscarded(repetition), sketch_discarded)
+                    );
+                    log_event!(logger, (LogEvent::GeneratedPairs(repetition), cnt));
+                    log_event!(
+                        logger,
+                        (LogEvent::DuplicatesDiscarded(repetition), duplicate_cnt)
+                    );
+                    Some(cnt)
+                },
+            )
             .exchange(|_| 0) // Bring all the counts to the first worker
             .unary(
                 timely::dataflow::channels::pact::Pipeline,

--- a/danny/src/lsh/algorithms/one_round.rs
+++ b/danny/src/lsh/algorithms/one_round.rs
@@ -176,7 +176,7 @@ where
         let end = Instant::now();
         pl.update(1u64);
         debug!("Repetition {} ended in {:?}", rep, end - start);
-        log_event!(logger, (LogEvent::GeneratedPairs(rep), examined_pairs));
+        log_event!(logger, (LogEvent::GeneratedPairs(rep), cnt));
         log_event!(logger, (LogEvent::SketchDiscarded(rep), sketch_discarded));
         log_event!(
             logger,

--- a/danny/src/lsh/algorithms/one_round.rs
+++ b/danny/src/lsh/algorithms/one_round.rs
@@ -176,7 +176,7 @@ where
         let end = Instant::now();
         pl.update(1u64);
         debug!("Repetition {} ended in {:?}", rep, end - start);
-        log_event!(logger, (LogEvent::GeneratedPairs(rep), cnt));
+        log_event!(logger, (LogEvent::OutputPairs(rep), cnt));
         log_event!(logger, (LogEvent::SketchDiscarded(rep), sketch_discarded));
         log_event!(
             logger,

--- a/danny/src/lsh/algorithms/two_round.rs
+++ b/danny/src/lsh/algorithms/two_round.rs
@@ -23,7 +23,7 @@ use timely::progress::Timestamp;
 use timely::worker::Worker;
 use timely::ExchangeData;
 
-pub const TWO_ROUND_VERSION: u8 = 4;
+pub const TWO_ROUND_VERSION: u8 = 5;
 
 #[allow(clippy::too_many_arguments)]
 pub fn two_round_lsh<D, F, H, B, R, S, V>(
@@ -110,6 +110,7 @@ where
         );
         hashes
             .self_join_map(
+                Balance::Load,
                 move |((outer_repetition, _h), subproblem_key), subproblem| {
                     let mut self_joiner = SelfJoiner::default();
                     let mut joiner = Joiner::default();

--- a/danny/src/lsh/algorithms/two_round.rs
+++ b/danny/src/lsh/algorithms/two_round.rs
@@ -188,7 +188,7 @@ where
                                 }
                             })
                         }
-                        log_event!(logger, (LogEvent::GeneratedPairs(outer_repetition), cnt));
+                        log_event!(logger, (LogEvent::OutputPairs(outer_repetition), cnt));
                         log_event!(
                             logger,
                             (LogEvent::SketchDiscarded(outer_repetition), sketch_cnt)

--- a/danny/src/lsh/algorithms/two_round.rs
+++ b/danny/src/lsh/algorithms/two_round.rs
@@ -23,7 +23,7 @@ use timely::progress::Timestamp;
 use timely::worker::Worker;
 use timely::ExchangeData;
 
-pub const TWO_ROUND_VERSION: u8 = 3;
+pub const TWO_ROUND_VERSION: u8 = 4;
 
 #[allow(clippy::too_many_arguments)]
 pub fn two_round_lsh<D, F, H, B, R, S, V>(

--- a/danny/src/lsh/algorithms/two_round.rs
+++ b/danny/src/lsh/algorithms/two_round.rs
@@ -414,6 +414,5 @@ impl Route for (usize, u32, CartesianKey) {
             .wrapping_mul(31u64)
             .wrapping_add(u64::from(self.1.route()))
             .wrapping_mul(31u64)
-            .wrapping_add(u64::from(self.2.route()))
     }
 }

--- a/danny/src/migrations/v3.sql
+++ b/danny/src/migrations/v3.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE result ADD COLUMN balance TEXT;
+
+PRAGMA user_version = 3;
+
+END TRANSACTION;

--- a/danny/src/operators.rs
+++ b/danny/src/operators.rs
@@ -123,6 +123,13 @@ impl Route for u64 {
     }
 }
 
+impl Route for u8 {
+    #[inline(always)]
+    fn route(&self) -> u64 {
+        *self as u64
+    }
+}
+
 impl Route for Vec<bool> {
     #[inline(always)]
     #[allow(clippy::cast_lossless)]
@@ -195,6 +202,7 @@ impl<R: Route> Route for (usize, R) {
             .wrapping_add(u64::from(self.1.route()))
     }
 }
+
 
 #[derive(Clone, Copy, Debug)]
 pub enum MatrixDirection {


### PR DESCRIPTION
In the two-round algorithm, consider _heavy hitters_, i.e. hash values with too many collisions, and solve the corresponding subproblem with a parallel cartesian product. Addresses #12 

- [x] Define precisely when a hash is a _heavy hitter_ (it's when its subproblem size is larger then `total / p`, with p the number of processors)